### PR TITLE
Update loading_tips.txt

### DIFF
--- a/english/loading_tips.txt
+++ b/english/loading_tips.txt
@@ -1,28 +1,28 @@
 This is a game meant to be complex and hard.
 Any similarities with another species would be purely fortuitous and unintentionnal.
-The economy is never stable. Things are always fluctuating, and that's because it is the result of a dynamic simulation where lots of things continuously influence each other. Do not worry if you cannot get everything to stay still.
-If a porco's income represent 3% of the region's total incomes, his wealth will be 3% of the region's total wealth.
-The income of a social class is shared equitably between all the porcos belonging to that class. The individual income of a porco is therefore an average value based on his social class total income.
+The economy is never stable. Things are always fluctuating. This is the result of a dynamic simulation where lots of things continuously influence each other. Do not worry if you cannot get everything to stay still.
+If a porco's income represents 3% of the combined income of everyone in the region, his wealth will be 3% of the region's total wealth.
+The income of a social class is shared equally between all the porcos belonging to that class. The individual income of a porco is therefore an average value based on his social class's total income.
 The market study of rare resources will tend to match the wealth of your richest classes while abundant ones will tend to match the wealth of the commoners.
 A porco with a wealth of 2 will be able to fully satisfy his needs of any resource costing 2 coins or less.
 If a resource costs 4 coins, a porco with a wealth of 1 can only satisfy 25% of his need for that resource.
-The wealth of a porco defines his purchasing power, like the resources he can afford to buy to satisfy his needs.
-Wealth is the unit of objective value. It's defined by time spent by a Porco working on anything, regardless of the subjective value (coin prices) his society gives to what he does. 
-Wealth, as a reference universal unit of value, is the same across all regions and players.
+The wealth of a porco defines his purchasing power which determines the resources he can afford to buy to satisfy his needs.
+Wealth is a unit of objective value. It's defined by the time spent by a Porco working on anything, regardless of the subjective value (coin price) his society gives to what he does. 
+Wealth, as a universal reference unit of value, is the same across all regions and players.
 Each Porco spending time working on something produces Wealth proportionnaly to the amount of work done.
 A Porco working in a building with twice the efficiency of another one will produce twice the amount of work in a day, and therefore twice the Wealth.
-The type or price of goods have no effect on Wealth. These things are relative to societies while wealth is an objective universal unit representing time spent working on anything.
-If one Porco earns 10 coins out of 1000 circulating (sum of incomes in the region) but then things change and there's suddenly 2000 circulating, it's like he lost half of what his coins are really worth and he lost half of the region wealth he used to have out if his 10 coins.
-Currencies represent a right to a share of real value, and do not necessarly have value by themselves. In Ymir that "real objective value" is the unit of "Wealth" represented by currencies called "Coins". 
-If the total region wealth was one pie, each coin would give a Porco the right to a slice of it. The size of the slice would depend on how many other coins are circulating (sum of all incomes in the region) .
-A region's sum of all incomes represents the total amount of coins circulating and therefore the ojective value (wealth) each coin represents.
-In ymir, to simplify and avoid the complication of relative currencies, the amount of coins in circulation is set automatically as the sum of all incomes. Therefore the actual value (Wealth) of each coin also fluctuates automatically depending on the total amount of incomes.
+Neither the type nor price of goods has an effect on Wealth. These things are relative to societies while wealth is a universal, objective unit representing the time spent working on anything.
+If one Porco earns 10 coins out of 1000 circulating coins (the sum of all the incomes in his region) but then things change and there are suddenly 2000 circulating coins, his coins have suddenly lost half of their worth and have gone from representing 1 percent of the region's total wealth to representing only 0.5 percent of the region's total wealth.
+Currencies represent a right to a share of real value, and do not necessarily have value by themselves. In Ymir that "real objective value" is the unit of "Wealth" represented by currencies called "Coins". 
+If the total region wealth was one pie, each coin would give a Porco the right to a slice of it. The size of the slice would depend on how many other coins are circulating (the sum of all the incomes in the region) .
+The total number of coins circulating in a region is the sum of all that region's incomes. This determines the ojective value (wealth) each coin represents.
+In Ymir, to simplify and avoid the complication of relative currencies, the amount of coins in circulation is set automatically as the sum of all incomes. Therefore, the actual value (Wealth) of each coin also fluctuates automatically depending on the total amount of incomes.
 You can still access the resources from a storage building with no workers, but it cannot receive any new ones.
-Any resource distributed and made available to the population (whether its by merchants, producers or anything else) are lost whether they're actually sold or not.
+Any resource distributed and made available to the population (whether through its merchants, producers, or anything else) is lost whether it is actually sold or not.
 The price of a resource will always be at least one coin above its production cost to ensure minimum benefits to its producers.
-If an industry produces something highly valued, the producers of its required materials will covet that industry's income and rise the price of their materials.
+If an industry produces something highly valued, the producers of the materials that industry requires will covet that industry's income and raise the price of their materials accordingly.
 Each project has an optimal number of researchers. Beyond that, any extra researchers will only add a minor contribution to the project.
 In a project, each researcher contributes 'research points' based on their intelligence.
 Be careful: assigning researchers to a project reduces the productivity of all buildings employing the same population class.
-You cannot directly control when and what ideas your people will have. Each idea comes with its own hidden conditions.
-In the building tab, you can still choose to build the previous now obsolete version of a building by right-clicking on the building's button.
+You cannot directly control what ideas your people will have nor can you directly control when they will have them. Each idea comes with its own hidden conditions.
+In the building tab, you can choose to build the previous, now obsolete, version of a building by right-clicking on the building's button.


### PR DESCRIPTION
I fixed a few typos and changed some phrasing to more accurately convey what was trying to be said.
In some cases, the changes in phrasing were drastic.
line 4: I'm unsure of whether the change <region's total incomes> to <combined income of everyone in the region> is completely necessary. It breaks the parallelism with the other tips.
line 5: Equally is the correct word in this situation. Equitably means something else.
line 15: This is the most drastic change in the file. The wording is quite different, but I really do think what I wrote better explains the idea you're trying to get across.
line18: This change is drastic in its positioning rather than its wording. The phrasing is now less awkward.
